### PR TITLE
Implemented Update Builder

### DIFF
--- a/builders/update.go
+++ b/builders/update.go
@@ -1,0 +1,12 @@
+package builders
+
+type UpdateBuilder interface {
+	UpdateFromBuilder
+	SetMap(colValMap map[string]any) UpdateFromBuilder
+	SetStruct(value any) UpdateFromBuilder
+}
+
+type UpdateFromBuilder interface {
+	Builder
+	From(table string, moreTable ...string) ReturningWhereBuilder
+}

--- a/builders/update.go
+++ b/builders/update.go
@@ -1,12 +1,21 @@
 package builders
 
+import (
+	incondition "github.com/williabk198/jagsqlb/internal/condition"
+)
+
 type UpdateBuilder interface {
 	UpdateFromBuilder
-	SetMap(colValMap map[string]any) UpdateFromBuilder
-	SetStruct(value any) UpdateFromBuilder
+	SetMap(colValMap map[string]any) UpdateFromWhereBuilder
+	SetStruct(value any) UpdateFromWhereBuilder
 }
 
 type UpdateFromBuilder interface {
 	Builder
 	From(table string, moreTable ...string) ReturningWhereBuilder
+}
+
+type UpdateFromWhereBuilder interface {
+	UpdateFromBuilder
+	Where(cond incondition.Condition, moreConds ...incondition.Condition) ReturningWhereBuilder
 }

--- a/internal/builders/update.go
+++ b/internal/builders/update.go
@@ -1,9 +1,13 @@
 package inbuilders
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/williabk198/jagsqlb/builders"
 	incondition "github.com/williabk198/jagsqlb/internal/condition"
 	intypes "github.com/williabk198/jagsqlb/internal/types"
+	"github.com/williabk198/jagsqlb/internal/utilities/parsers"
 )
 
 type updateBuilder struct {
@@ -16,28 +20,141 @@ type updateBuilder struct {
 
 // Build implements builders.UpdateBuilder.
 func (u updateBuilder) Build() (query string, queryParams []any, err error) {
-	panic("unimplemented")
+	if len(u.errs) > 0 {
+		return "", nil, fmt.Errorf("failed to build base update query: %w", u.errs)
+	}
+
+	sb := new(strings.Builder)
+	sb.WriteString("UPDATE ")
+	sb.WriteString(u.table.String())
+
+	sb.WriteString(" SET ")
+	sb.WriteString(u.columns[0].String())
+	sb.WriteRune('=')
+	if cv, ok := u.vals[0].(incondition.ColumnValue); ok {
+		sb.WriteString(cv.ColumnName)
+	} else {
+		sb.WriteRune('?')
+	}
+
+	for i := 1; i < len(u.columns); i++ {
+		sb.WriteString(", ")
+		sb.WriteString(u.columns[i].String())
+		sb.WriteRune('=')
+		if cv, ok := u.vals[i].(incondition.ColumnValue); ok {
+			sb.WriteString(cv.ColumnName)
+		} else {
+			sb.WriteRune('?')
+		}
+	}
+
+	if len(u.fromTables) > 0 {
+		sb.WriteString(" FROM ")
+		sb.WriteString(u.fromTables[0].String())
+		for i := 1; i < len(u.fromTables); i++ {
+			sb.WriteString(", ")
+			sb.WriteString(u.fromTables[i].String())
+		}
+	}
+
+	sb.WriteRune(';')
+
+	// Go through the values and remove any value that is of the type `incondition.ColumnValue`.
+	// Doing this here instead of inside the previous maybe slightly more inefficient, but easier to understand.
+	// Performance issues will be handled later, if the need arises.
+	for i := range u.vals {
+		if _, ok := u.vals[i].(incondition.ColumnValue); ok {
+			u.vals = append(u.vals[:i], u.vals[i+1:])
+		}
+	}
+
+	return finalizeQuery(sb.String()), u.vals, nil
 }
 
 // SetMap implements builders.UpdateBuilder.
 func (u updateBuilder) SetMap(colValMap map[string]any) builders.UpdateFromWhereBuilder {
-	panic("unimplemented")
+	u.columns = make([]intypes.Column, len(colValMap))
+	u.vals = make([]any, len(colValMap))
+
+	i := 0
+	for k, v := range colValMap {
+		colData, err := columnParser.Parse(k)
+		if err != nil {
+			u.errs = append(u.errs, err)
+			return u
+		}
+		u.columns[i] = colData
+		u.vals[i] = v
+		i++
+	}
+
+	return u
 }
 
 // SetStruct implements builders.UpdateBuilder.
 func (u updateBuilder) SetStruct(value any) builders.UpdateFromWhereBuilder {
-	panic("unimplemented")
+	cols, vals, err := parsers.ParseColumnTag(value)
+	if err != nil {
+		u.errs = append(u.errs, fmt.Errorf("failed to process argument of SetStruct: %w", err))
+		return u
+	}
+
+	u.columns = make([]intypes.Column, len(cols))
+	for i, c := range cols {
+		colData, err := columnParser.Parse(c)
+		if err != nil {
+			u.errs = append(u.errs, err)
+			return u
+		}
+		u.columns[i] = colData
+	}
+	u.vals = vals
+
+	return u
 }
 
 // From implements builders.UpdateBuilder.
 func (u updateBuilder) From(table string, moreTables ...string) builders.ReturningWhereBuilder {
-	panic("unimplemented")
+	tableData, err := tableParser.Parse(table)
+	if err != nil {
+		u.errs = append(u.errs, err)
+		return returningWhereBuilder{
+			mainQuery: u,
+		}
+	}
+	u.fromTables = append(u.fromTables, tableData)
+
+	for _, mt := range moreTables {
+		tableData, err = tableParser.Parse(mt)
+		if err != nil {
+			u.errs = append(u.errs, err)
+			return returningWhereBuilder{
+				mainQuery: u,
+			}
+		}
+		u.fromTables = append(u.fromTables, tableData)
+	}
+
+	return returningWhereBuilder{
+		mainQuery: u,
+	}
 }
 
 func (u updateBuilder) Where(cond incondition.Condition, moreConds ...incondition.Condition) builders.ReturningWhereBuilder {
-	panic("unimplemented")
+	rwb := returningWhereBuilder{
+		mainQuery: u,
+	}
+	return rwb.And(cond, moreConds...)
 }
 
 func NewUpdateBuilder(table string) builders.UpdateBuilder {
-	panic("unimplemented")
+	ub := updateBuilder{}
+
+	tableData, err := tableParser.Parse(table)
+	if err != nil {
+		ub.errs = append(ub.errs, err)
+		return ub
+	}
+	ub.table = tableData
+	return ub
 }

--- a/internal/builders/update.go
+++ b/internal/builders/update.go
@@ -2,15 +2,16 @@ package inbuilders
 
 import (
 	"github.com/williabk198/jagsqlb/builders"
+	incondition "github.com/williabk198/jagsqlb/internal/condition"
 	intypes "github.com/williabk198/jagsqlb/internal/types"
 )
 
 type updateBuilder struct {
-	table     intypes.Table
-	columns   []intypes.Column
-	vals      []any
-	fromTable []intypes.Table
-	errs      intypes.ErrorSlice
+	table      intypes.Table
+	columns    []intypes.Column
+	vals       []any
+	fromTables []intypes.Table
+	errs       intypes.ErrorSlice
 }
 
 // Build implements builders.UpdateBuilder.
@@ -19,17 +20,21 @@ func (u updateBuilder) Build() (query string, queryParams []any, err error) {
 }
 
 // SetMap implements builders.UpdateBuilder.
-func (u updateBuilder) SetMap(colValMap map[string]any) builders.UpdateFromBuilder {
+func (u updateBuilder) SetMap(colValMap map[string]any) builders.UpdateFromWhereBuilder {
 	panic("unimplemented")
 }
 
 // SetStruct implements builders.UpdateBuilder.
-func (u updateBuilder) SetStruct(value any) builders.UpdateFromBuilder {
+func (u updateBuilder) SetStruct(value any) builders.UpdateFromWhereBuilder {
 	panic("unimplemented")
 }
 
 // From implements builders.UpdateBuilder.
 func (u updateBuilder) From(table string, moreTables ...string) builders.ReturningWhereBuilder {
+	panic("unimplemented")
+}
+
+func (u updateBuilder) Where(cond incondition.Condition, moreConds ...incondition.Condition) builders.ReturningWhereBuilder {
 	panic("unimplemented")
 }
 

--- a/internal/builders/update.go
+++ b/internal/builders/update.go
@@ -1,0 +1,38 @@
+package inbuilders
+
+import (
+	"github.com/williabk198/jagsqlb/builders"
+	intypes "github.com/williabk198/jagsqlb/internal/types"
+)
+
+type updateBuilder struct {
+	table     intypes.Table
+	columns   []intypes.Column
+	vals      []any
+	fromTable []intypes.Table
+	errs      intypes.ErrorSlice
+}
+
+// Build implements builders.UpdateBuilder.
+func (u updateBuilder) Build() (query string, queryParams []any, err error) {
+	panic("unimplemented")
+}
+
+// SetMap implements builders.UpdateBuilder.
+func (u updateBuilder) SetMap(colValMap map[string]any) builders.UpdateFromBuilder {
+	panic("unimplemented")
+}
+
+// SetStruct implements builders.UpdateBuilder.
+func (u updateBuilder) SetStruct(value any) builders.UpdateFromBuilder {
+	panic("unimplemented")
+}
+
+// From implements builders.UpdateBuilder.
+func (u updateBuilder) From(table string, moreTables ...string) builders.ReturningWhereBuilder {
+	panic("unimplemented")
+}
+
+func NewUpdateBuilder(table string) builders.UpdateBuilder {
+	panic("unimplemented")
+}

--- a/internal/builders/update_test.go
+++ b/internal/builders/update_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/williabk198/jagsqlb/builders"
+	"github.com/williabk198/jagsqlb/condition"
+	incondition "github.com/williabk198/jagsqlb/internal/condition"
 	intypes "github.com/williabk198/jagsqlb/internal/types"
 )
 
@@ -238,6 +240,49 @@ func Test_updateBuilder_From(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, tt.u.From(tt.args.table, tt.args.moreTables...))
+		})
+	}
+}
+
+func Test_updateBuilder_Where(t *testing.T) {
+	type args struct {
+		cond      incondition.Condition
+		moreConds []incondition.Condition
+	}
+	tests := []struct {
+		name string
+		u    updateBuilder
+		args args
+		want builders.ReturningWhereBuilder
+	}{
+		{
+			name: "Success",
+			u: updateBuilder{
+				table:   intypes.Table{Name: "table1"},
+				columns: []intypes.Column{{Name: "col1"}},
+				vals:    []any{"test"},
+			},
+			args: args{
+				cond: condition.Equals("col2", 56),
+			},
+			want: returningWhereBuilder{
+				mainQuery: updateBuilder{
+					table:   intypes.Table{Name: "table1"},
+					columns: []intypes.Column{{Name: "col1"}},
+					vals:    []any{"test"},
+				},
+				conditions: whereConditions{
+					{
+						conjunction: "AND",
+						condition:   condition.Equals("col2", 56),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.u.Where(tt.args.cond, tt.args.moreConds...))
 		})
 	}
 }

--- a/internal/builders/update_test.go
+++ b/internal/builders/update_test.go
@@ -34,7 +34,7 @@ func Test_updateBuilder_Build(t *testing.T) {
 				query:  `UPDATE "table1" SET "col1"=$1, "col2"=$2;`,
 				params: []any{"testing", 137},
 			},
-			assertion: assert.Error,
+			assertion: assert.NoError,
 		},
 		{
 			name: "Sucess; w/ From",
@@ -48,13 +48,14 @@ func Test_updateBuilder_Build(t *testing.T) {
 					"testing",
 					137,
 				},
-				fromTable: []intypes.Table{
+				fromTables: []intypes.Table{
 					{Name: "table2"},
 					{Name: "table3"},
 				},
 			},
 			wants: wants{
-				query: `UPDATE "table1" SET "col1"=$1, "col2"=$2 FROM "table2", "table3";`,
+				query:  `UPDATE "table1" SET "col1"=$1, "col2"=$2 FROM "table2", "table3";`,
+				params: []any{"testing", 137},
 			},
 			assertion: assert.NoError,
 		},
@@ -84,7 +85,7 @@ func Test_updateBuilder_SetMap(t *testing.T) {
 		name string
 		u    updateBuilder
 		args args
-		want builders.UpdateFromBuilder
+		want builders.UpdateFromWhereBuilder
 	}{
 		{
 			name: "Success",
@@ -125,7 +126,7 @@ func Test_updateBuilder_SetStruct(t *testing.T) {
 		name string
 		u    updateBuilder
 		args args
-		want builders.UpdateFromBuilder
+		want builders.UpdateFromWhereBuilder
 	}{
 		{
 			name: "Success; No Struct Tag",
@@ -148,7 +149,7 @@ func Test_updateBuilder_SetStruct(t *testing.T) {
 			},
 			want: updateBuilder{
 				columns: []intypes.Column{{Name: "data"}},
-				vals:    []any{53},
+				vals:    []any{153},
 			},
 		},
 		{
@@ -193,7 +194,7 @@ func Test_updateBuilder_From(t *testing.T) {
 			},
 			want: returningWhereBuilder{
 				mainQuery: updateBuilder{
-					fromTable: []intypes.Table{
+					fromTables: []intypes.Table{
 						{Name: "table2"},
 					},
 				},
@@ -208,7 +209,7 @@ func Test_updateBuilder_From(t *testing.T) {
 			},
 			want: returningWhereBuilder{
 				mainQuery: updateBuilder{
-					fromTable: []intypes.Table{
+					fromTables: []intypes.Table{
 						{Name: "table2"},
 						{Name: "table3"},
 					},
@@ -238,6 +239,7 @@ func Test_updateBuilder_From(t *testing.T) {
 			},
 			want: returningWhereBuilder{
 				mainQuery: updateBuilder{
+					fromTables: []intypes.Table{{Name: "table2"}},
 					errs: intypes.ErrorSlice{
 						fmt.Errorf("failed to parse table data from %q: %w", ".bad_table", intypes.ErrMissingSchemaName),
 					},
@@ -274,17 +276,6 @@ func TestNewUpdateBuilder(t *testing.T) {
 			name: "Error; Bad Table Name",
 			args: args{
 				table: ".bad_table",
-			},
-			want: updateBuilder{
-				errs: intypes.ErrorSlice{
-					fmt.Errorf("failed to parse table data from %q: %w", ".bad_table", intypes.ErrMissingSchemaName),
-				},
-			},
-		},
-		{
-			name: "Error; Bad MoreTable Name",
-			args: args{
-				table: "table1",
 			},
 			want: updateBuilder{
 				errs: intypes.ErrorSlice{

--- a/internal/builders/update_test.go
+++ b/internal/builders/update_test.go
@@ -91,23 +91,11 @@ func Test_updateBuilder_SetMap(t *testing.T) {
 			name: "Success",
 			u:    updateBuilder{},
 			args: args{
-				colValMap: map[string]any{
-					"col1": "something",
-					"col2": 12.34,
-					"col3": 987,
-				},
+				colValMap: map[string]any{"col1": "something"},
 			},
 			want: updateBuilder{
-				columns: []intypes.Column{
-					{Name: "col1"},
-					{Name: "col2"},
-					{Name: "col3"},
-				},
-				vals: []any{
-					"something",
-					12.34,
-					987,
-				},
+				columns: []intypes.Column{{Name: "col1"}},
+				vals:    []any{"something"},
 			},
 		},
 	}

--- a/internal/builders/update_test.go
+++ b/internal/builders/update_test.go
@@ -1,0 +1,301 @@
+package inbuilders
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/williabk198/jagsqlb/builders"
+	intypes "github.com/williabk198/jagsqlb/internal/types"
+)
+
+func Test_updateBuilder_Build(t *testing.T) {
+	type wants struct {
+		query  string
+		params []any
+	}
+	tests := []struct {
+		name      string
+		u         updateBuilder
+		wants     wants
+		assertion assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Success; w/o From",
+			u: updateBuilder{
+				table: intypes.Table{Name: "table1"},
+				columns: []intypes.Column{
+					{Name: "col1"},
+					{Name: "col2"},
+				},
+				vals: []any{"testing", 137},
+			},
+			wants: wants{
+				query:  `UPDATE "table1" SET "col1"=$1, "col2"=$2;`,
+				params: []any{"testing", 137},
+			},
+			assertion: assert.Error,
+		},
+		{
+			name: "Sucess; w/ From",
+			u: updateBuilder{
+				table: intypes.Table{Name: "table1"},
+				columns: []intypes.Column{
+					{Name: "col1"},
+					{Name: "col2"},
+				},
+				vals: []any{
+					"testing",
+					137,
+				},
+				fromTable: []intypes.Table{
+					{Name: "table2"},
+					{Name: "table3"},
+				},
+			},
+			wants: wants{
+				query: `UPDATE "table1" SET "col1"=$1, "col2"=$2 FROM "table2", "table3";`,
+			},
+			assertion: assert.NoError,
+		},
+		{
+			name: "Error; ErrorSlice not Empty",
+			u: updateBuilder{
+				errs: intypes.ErrorSlice{assert.AnError},
+			},
+			assertion: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotQuery, gotQueryParams, err := tt.u.Build()
+			tt.assertion(t, err)
+			assert.Equal(t, tt.wants.query, gotQuery)
+			assert.Equal(t, tt.wants.params, gotQueryParams)
+		})
+	}
+}
+
+func Test_updateBuilder_SetMap(t *testing.T) {
+	type args struct {
+		colValMap map[string]any
+	}
+	tests := []struct {
+		name string
+		u    updateBuilder
+		args args
+		want builders.UpdateFromBuilder
+	}{
+		{
+			name: "Success",
+			u:    updateBuilder{},
+			args: args{
+				colValMap: map[string]any{
+					"col1": "something",
+					"col2": 12.34,
+					"col3": 987,
+				},
+			},
+			want: updateBuilder{
+				columns: []intypes.Column{
+					{Name: "col1"},
+					{Name: "col2"},
+					{Name: "col3"},
+				},
+				vals: []any{
+					"something",
+					12.34,
+					987,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.u.SetMap(tt.args.colValMap))
+		})
+	}
+}
+
+func Test_updateBuilder_SetStruct(t *testing.T) {
+	type args struct {
+		value any
+	}
+	tests := []struct {
+		name string
+		u    updateBuilder
+		args args
+		want builders.UpdateFromBuilder
+	}{
+		{
+			name: "Success; No Struct Tag",
+			u:    updateBuilder{},
+			args: args{
+				value: struct{ Data string }{"testing"},
+			},
+			want: updateBuilder{
+				columns: []intypes.Column{{Name: "Data"}},
+				vals:    []any{"testing"},
+			},
+		},
+		{
+			name: "Success; With Struct Tag",
+			u:    updateBuilder{},
+			args: args{
+				value: struct {
+					Data int `jagsqlb:"data"`
+				}{153},
+			},
+			want: updateBuilder{
+				columns: []intypes.Column{{Name: "data"}},
+				vals:    []any{53},
+			},
+		},
+		{
+			name: "Error; Invalid Input Type",
+			u:    updateBuilder{},
+			args: args{
+				value: "bad_val",
+			},
+			want: updateBuilder{
+				errs: intypes.ErrorSlice{
+					fmt.Errorf(
+						"failed to process argument of SetStruct: %w",
+						fmt.Errorf("recieved value is not a struct type"),
+					),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.u.SetStruct(tt.args.value))
+		})
+	}
+}
+
+func Test_updateBuilder_From(t *testing.T) {
+	type args struct {
+		table      string
+		moreTables []string
+	}
+	tests := []struct {
+		name string
+		u    updateBuilder
+		args args
+		want builders.ReturningWhereBuilder
+	}{
+		{
+			name: "Success; Single Table",
+			u:    updateBuilder{},
+			args: args{
+				table: "table2",
+			},
+			want: returningWhereBuilder{
+				mainQuery: updateBuilder{
+					fromTable: []intypes.Table{
+						{Name: "table2"},
+					},
+				},
+			},
+		},
+		{
+			name: "Success; Multiple Tables",
+			u:    updateBuilder{},
+			args: args{
+				table:      "table2",
+				moreTables: []string{"table3"},
+			},
+			want: returningWhereBuilder{
+				mainQuery: updateBuilder{
+					fromTable: []intypes.Table{
+						{Name: "table2"},
+						{Name: "table3"},
+					},
+				},
+			},
+		},
+		{
+			name: "Error; Bad Table Name",
+			u:    updateBuilder{},
+			args: args{
+				table: ".bad_table",
+			},
+			want: returningWhereBuilder{
+				mainQuery: updateBuilder{
+					errs: intypes.ErrorSlice{
+						fmt.Errorf("failed to parse table data from %q: %w", ".bad_table", intypes.ErrMissingSchemaName),
+					},
+				},
+			},
+		},
+		{
+			name: "Error; Bad MoreTable Name",
+			u:    updateBuilder{},
+			args: args{
+				table:      "table2",
+				moreTables: []string{".bad_table"},
+			},
+			want: returningWhereBuilder{
+				mainQuery: updateBuilder{
+					errs: intypes.ErrorSlice{
+						fmt.Errorf("failed to parse table data from %q: %w", ".bad_table", intypes.ErrMissingSchemaName),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.u.From(tt.args.table, tt.args.moreTables...))
+		})
+	}
+}
+
+func TestNewUpdateBuilder(t *testing.T) {
+	type args struct {
+		table string
+	}
+	tests := []struct {
+		name string
+		args args
+		want builders.UpdateBuilder
+	}{
+		{
+			name: "Success",
+			args: args{
+				table: "table1",
+			},
+			want: updateBuilder{
+				table: intypes.Table{Name: "table1"},
+			},
+		},
+		{
+			name: "Error; Bad Table Name",
+			args: args{
+				table: ".bad_table",
+			},
+			want: updateBuilder{
+				errs: intypes.ErrorSlice{
+					fmt.Errorf("failed to parse table data from %q: %w", ".bad_table", intypes.ErrMissingSchemaName),
+				},
+			},
+		},
+		{
+			name: "Error; Bad MoreTable Name",
+			args: args{
+				table: "table1",
+			},
+			want: updateBuilder{
+				errs: intypes.ErrorSlice{
+					fmt.Errorf("failed to parse table data from %q: %w", ".bad_table", intypes.ErrMissingSchemaName),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, NewUpdateBuilder(tt.args.table))
+		})
+	}
+}

--- a/jagsqlb.go
+++ b/jagsqlb.go
@@ -9,6 +9,7 @@ import (
 type SqlBuilder interface {
 	Delete(table string) builders.DeleteBuilder
 	Select(table string, columns ...string) builders.SelectBuilder
+	Update(table string) builders.UpdateBuilder
 }
 
 type sqlBuilder struct{}
@@ -23,6 +24,10 @@ func (sb sqlBuilder) Insert(table string) builders.InsertBuilder {
 
 func (sb sqlBuilder) Select(table string, columns ...string) builders.SelectBuilder {
 	return inbuilders.NewSelectBuilder(table, columns...)
+}
+
+func (sb sqlBuilder) Update(table string) builders.UpdateBuilder {
+	return inbuilders.NewUpdateBuilder(table)
 }
 
 // NewSelectBuilder creates and returns a reusable SQL Builder


### PR DESCRIPTION
Added the ability to build `UPDATE` statements.

It can also handle using structs to build the update statement. However, zero-valued fields will still be included and there isn't a way to explicitly ignore values at the moment if structs are used to build the query.