### PR TITLE
Added Handling of Nested Structs and Omit Tag

### DIFF
--- a/internal/utilities/parsers/tag_parser_test.go
+++ b/internal/utilities/parsers/tag_parser_test.go
@@ -15,6 +15,10 @@ func TestColumnTagParser(t *testing.T) {
 		vals []any
 	}
 
+	type innerTestStruct struct {
+		Data string `jagsqlb:"inner_data"`
+	}
+
 	tests := []struct {
 		name      string
 		args      args
@@ -42,6 +46,44 @@ func TestColumnTagParser(t *testing.T) {
 			wants: wants{
 				cols: []string{"data"},
 				vals: []any{52},
+			},
+			assertion: assert.NoError,
+		},
+		{
+			name: "Success; With Nested Struct",
+			args: args{
+				input: struct {
+					Data      string `jagsqlb:"data"`
+					InnerData innerTestStruct
+				}{
+					Data: "outer",
+					InnerData: innerTestStruct{
+						Data: "inner",
+					},
+				},
+			},
+			wants: wants{
+				cols: []string{"data", "inner_data"},
+				vals: []any{"outer", "inner"},
+			},
+			assertion: assert.NoError,
+		},
+		{
+			name: "Success; With Omitted Field",
+			args: args{
+				input: struct {
+					Data      string          `jagsqlb:"data"`
+					InnerData innerTestStruct `jagsqlb:";omit"`
+				}{
+					Data: "outer",
+					InnerData: innerTestStruct{
+						Data: "inner",
+					},
+				},
+			},
+			wants: wants{
+				cols: []string{"data"},
+				vals: []any{"outer"},
 			},
 			assertion: assert.NoError,
 		},


### PR DESCRIPTION
If a struct passed to `ParseColumnTag` has a nested struct within it, the fields within the struct will now be properly added to the result set by default.

As a result of these changes, an `omit` tag has been added so that users have the ability to leave out a field from being included in the result of the query builder.