### PR TITLE
Fixed Issue with DeleteBuilder's Where Function 

### DIFF
--- a/internal/builders/delete.go
+++ b/internal/builders/delete.go
@@ -61,7 +61,7 @@ func (d deleteBuilder) Using(table string) builders.DeleteBuilder {
 
 // Where implements builders.DeleteBuilder.
 func (d deleteBuilder) Where(condition incondition.Condition, moreConditions ...incondition.Condition) builders.ReturningWhereBuilder {
-	rwb := returningWhereBuilder{
+	var rwb builders.ReturningWhereBuilder = returningWhereBuilder{
 		mainQuery: d,
 		conditions: whereConditions{
 			{condition: condition},
@@ -69,7 +69,7 @@ func (d deleteBuilder) Where(condition incondition.Condition, moreConditions ...
 	}
 
 	if len(moreConditions) > 0 {
-		rwb.And(moreConditions[0], moreConditions[1:]...)
+		rwb = rwb.And(moreConditions[0], moreConditions[1:]...)
 	}
 
 	return rwb

--- a/internal/builders/delete_test.go
+++ b/internal/builders/delete_test.go
@@ -129,7 +129,7 @@ func Test_deleteBuilder_Where(t *testing.T) {
 		want builders.ReturningWhereBuilder
 	}{
 		{
-			name: "Success",
+			name: "Success; Single Condition",
 			d:    deleteBuilder{},
 			args: args{
 				condition: condition.Equals("col1", 52),
@@ -138,6 +138,23 @@ func Test_deleteBuilder_Where(t *testing.T) {
 				mainQuery: deleteBuilder{},
 				conditions: whereConditions{
 					{condition: condition.Equals("col1", 52)},
+				},
+			},
+		},
+		{
+			name: "Success; Multiple Conditions",
+			d:    deleteBuilder{},
+			args: args{
+				condition: condition.Equals("col1", 52),
+				moreConditions: []incondition.Condition{
+					condition.GreaterThan("col2", 77),
+				},
+			},
+			want: returningWhereBuilder{
+				mainQuery: deleteBuilder{},
+				conditions: whereConditions{
+					{condition: condition.Equals("col1", 52)},
+					{conjunction: "AND", condition: condition.GreaterThan("col2", 77)},
 				},
 			},
 		},


### PR DESCRIPTION
When using Where in the Delete builder, only the first parameter was being added to the slice of conditions. This is now fixed.

Closes #15 