### PR TITLE
Fixed Panic for Returning Builders 

### DIFF
--- a/internal/builders/returning.go
+++ b/internal/builders/returning.go
@@ -27,11 +27,13 @@ func (rb returningBuilder) Build() (string, []any, error) {
 	sb := new(strings.Builder)
 	sb.WriteString(query[:len(query)-1])
 
-	sb.WriteString(" RETURNING ")
-	sb.WriteString(rb.returningColumns[0].String())
-	for i := 1; i < len(rb.returningColumns); i++ {
-		sb.WriteString(", ")
-		sb.WriteString(rb.returningColumns[i].String())
+	if len(rb.returningColumns) > 0 {
+		sb.WriteString(" RETURNING ")
+		sb.WriteString(rb.returningColumns[0].String())
+		for i := 1; i < len(rb.returningColumns); i++ {
+			sb.WriteString(", ")
+			sb.WriteString(rb.returningColumns[i].String())
+		}
 	}
 	sb.WriteRune(';')
 

--- a/internal/builders/returning_test.go
+++ b/internal/builders/returning_test.go
@@ -52,6 +52,18 @@ func Test_returningBuilder_Build(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
+			name: "Success; No Columns Provided",
+			rb: returningBuilder{
+				prevBuilder:      NewInsertBuilder("table1").Data(struct{ Data string }{"test"}),
+				returningColumns: []intypes.Column{},
+			},
+			wants: wants{
+				query:  `INSERT INTO "table1" ("Data") VALUES ($1);`,
+				params: []any{"test"},
+			},
+			assertion: assert.NoError,
+		},
+		{
 			name: "Error; ErrorSlice not Empty",
 			rb: returningBuilder{
 				errs: intypes.ErrorSlice{assert.AnError},


### PR DESCRIPTION
Fixed an issue with Builders that can construct a "RETURNING" clause (Insert, Update & Delete builders). If the `Returning` function was not called before calling `Build`, then a panic would occur. This is now resolved

Closes #17 